### PR TITLE
Add parallel appointment watcher with Fly.io support

### DIFF
--- a/appointments.example.toml
+++ b/appointments.example.toml
@@ -1,0 +1,31 @@
+# Example configuration for running multiple appointment searches in parallel.
+# Copy this file to appointments.toml and adjust the values to match your filters.
+
+[settings]
+max_parallel = 3
+
+[[jobs]]
+label = "endo-phone"
+region = 202
+specialty = [27962]
+doctor = 334258
+interval = 10
+notification = "telegram"
+title = " Endokrynolog dorośli - porada telefoniczna"
+
+[[jobs]]
+label = "allergy"
+region = 202
+specialty = [178]
+doctor = 499430
+interval = 10
+notification = "telegram"
+title = " Alergolog dorośli odczulani"
+
+[[jobs]]
+label = "laryngology"
+region = 202
+specialty = [192]
+interval = 10
+notification = "telegram"
+title = " Laryngolog dorośli"

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,34 @@
+app = "medichaser"
+primary_region = "waw"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  APPOINTMENTS_CONFIG = "/app/data/appointments.toml"
+  PYTHONUNBUFFERED = "1"
+
+[processes]
+  web = "ttyd -W bash"
+  watcher = [
+    "/bin/sh",
+    "-c",
+    "python medichaser.py find-appointments --config ${APPOINTMENTS_CONFIG}"
+  ]
+
+[[services]]
+  processes = ["web"]
+  internal_port = 7681
+  protocol = "tcp"
+
+  [[services.ports]]
+    handlers = ["http"]
+    port = 80
+
+  [[services.ports]]
+    handlers = ["tls", "http"]
+    port = 443
+
+[[mounts]]
+  source = "medichaser_data"
+  destination = "/app/data"


### PR DESCRIPTION
## Summary
- add a thread-safe notification cache and extract find-appointment logic so multiple jobs can run in parallel from a TOML config
- introduce a new `find-appointments` command, example configuration, and documentation on configuring concurrency and Fly.io deployment
- update tests to cover the new behaviours and ensure notifications are delivered only once per appointment

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfbe26a0ec8326aa738fa7be2d938e