### PR TITLE
Run find-appointments jobs sequentially

### DIFF
--- a/appointments.example.toml
+++ b/appointments.example.toml
@@ -1,8 +1,8 @@
-# Example configuration for running multiple appointment searches in parallel.
+# Example configuration for running multiple appointment searches sequentially.
 # Copy this file to appointments.toml and adjust the values to match your filters.
 
 [settings]
-max_parallel = 3
+loop_interval_seconds = 30
 
 [[jobs]]
 label = "endo-phone"

--- a/appointments.toml
+++ b/appointments.toml
@@ -1,5 +1,5 @@
 [settings]
-max_parallel = 3
+loop_interval_seconds = 30
 
 [[jobs]]
 label = "endo-phone"


### PR DESCRIPTION
## Summary
- replace the parallel thread pool with a sequential scheduler that loops through jobs using a configurable loop interval
- document the sequential workflow and update example configurations to use `loop_interval_seconds`
- refresh automated tests to cover the sequential scheduler and new configuration options

## Testing
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfdbd1e39c8326a6ec993cd012e80a