### PR TITLE
Improve Telegram appointment formatting readability

### DIFF
--- a/medichaser.py
+++ b/medichaser.py
@@ -852,7 +852,7 @@ class Notifier:
         if not appointments:
             return "No appointments found."
 
-        messages = []
+        messages: list[str] = []
         for appointment in appointments:
             date = appointment.get("appointmentDate", "N/A")
             clinic = appointment.get("clinic", {}).get("name", "N/A")
@@ -864,16 +864,18 @@ class Notifier:
                 if doctor_languages
                 else "N/A"
             )
-            message = (
-                    f"Date: {date}\n"
-                    f"Clinic: {clinic}\n"
-                    f"Doctor: {doctor}\n"
-                    f"Languages: {languages}\n"
-                    + f"Specialty: {specialty}\n"
-                    + "--------------------------------------------------"
-            )
+
+            fields = [
+                ("📅 Date", date),
+                ("🏥 Clinic", clinic),
+                ("👨‍⚕️ Doctor", doctor),
+                ("🩺 Specialty", specialty),
+                ("🗣️ Languages", languages),
+            ]
+            message = "\n".join(f"{label}: {value}" for label, value in fields)
             messages.append(message)
-        return "\n".join(messages)
+
+        return "\n\n".join(messages)
 
     @staticmethod
     @tenacity.retry(

--- a/notifications.py
+++ b/notifications.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from html import escape
 from os import environ
 
 import requests
@@ -80,10 +81,12 @@ def pushover_notify(message: str, title: str | None = None) -> None:
 
 def telegram_notify(message: str, title: str | None = None) -> None:
     try:
+        safe_message = escape(message, quote=False)
         if title:
-            message = f"<b>{title}</b>\n{message}"
+            safe_title = escape(title, quote=False)
+            safe_message = f"<b>{safe_title}</b>\n\n{safe_message}"
 
-        r = telegram.notify(message=message, parse_mode="html")
+        r = telegram.notify(message=safe_message, parse_mode="html")
     except BadArguments as e:
         print(
             f"Telegram notifications require NOTIFIERS_TELEGRAM_CHAT_ID"

--- a/tests.py
+++ b/tests.py
@@ -562,11 +562,11 @@ class TestNotifier:
 
         result = Notifier.format_appointments(appointments)
 
-        assert "Date: 2025-01-01T10:00:00" in result
-        assert "Clinic: Test Clinic" in result
-        assert "Doctor: Dr. Test" in result
-        assert "Specialty: Cardiology" in result
-        assert "Languages: English, Polish" in result
+        assert "📅 Date: 2025-01-01T10:00:00" in result
+        assert "🏥 Clinic: Test Clinic" in result
+        assert "👨‍⚕️ Doctor: Dr. Test" in result
+        assert "🩺 Specialty: Cardiology" in result
+        assert "🗣️ Languages: English, Polish" in result
 
     def test_format_appointments_multiple(self) -> None:
         """Test formatting multiple appointments."""
@@ -589,12 +589,13 @@ class TestNotifier:
 
         result = Notifier.format_appointments(appointments)
 
-        assert "Clinic 1" in result
-        assert "Clinic 2" in result
-        assert "Dr. One" in result
-        assert "Dr. Two" in result
-        assert "Languages: N/A" in result  # First appointment has no languages
-        assert "Languages: Polish" in result  # Second appointment has Polish
+        assert "🏥 Clinic: Clinic 1" in result
+        assert "🏥 Clinic: Clinic 2" in result
+        assert "👨‍⚕️ Doctor: Dr. One" in result
+        assert "👨‍⚕️ Doctor: Dr. Two" in result
+        assert "🗣️ Languages: N/A" in result  # First appointment has no languages
+        assert "🗣️ Languages: Polish" in result  # Second appointment has Polish
+        assert "\n\n" in result  # Appointments separated by a blank line for readability
 
     def test_send_notification_pushbullet(
             self, monkeypatch: pytest.MonkeyPatch
@@ -1127,7 +1128,7 @@ class TestNotificationFunctions:
         telegram_notify("Test message", "Test title")
 
         mock_telegram.notify.assert_called_once_with(
-            message="<b>Test title</b>\nTest message", parse_mode="html"
+            message="<b>Test title</b>\n\nTest message", parse_mode="html"
         )
 
     def test_telegram_notify_without_title(


### PR DESCRIPTION
## Summary
- format appointment notifications with icons and spacing to read better on mobile devices
- escape Telegram title/message content and add spacing when sending notifications
- update notifier unit tests to cover the new formatting expectations

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d007721d108326a5bfbfcf03f1a1b3